### PR TITLE
fix: ensure number in border title is correct

### DIFF
--- a/skan/src/BoardState.scala
+++ b/skan/src/BoardState.scala
@@ -75,13 +75,17 @@ final case class BoardState(
         val newlySelected = todoState.selected match
           case None => if todoItems().isEmpty then None else Some(0)
           case Some(i) =>
-            if i == 0 then Some(todoItems().length - 1) else Some(i - 1)
+            if todoItems().isEmpty then None
+            else if i == 0 then Some(todoItems().length - 1)
+            else Some(i - 1)
         todoState.select(newlySelected)
       case Status.INPROGRESS =>
         val newlySelected = inProgressState.selected match
           case None => if inProgressItems().isEmpty then None else Some(0)
           case Some(i) =>
-            if i == 0 then Some(inProgressItems().length - 1) else Some(i - 1)
+            if inProgressItems().isEmpty then None
+            else if i == 0 then Some(inProgressItems().length - 1)
+            else Some(i - 1)
         inProgressState.select(newlySelected)
       case _ => ()
 
@@ -93,16 +97,22 @@ final case class BoardState(
         todoState.selected match
           case None => ()
           case Some(selectedIndex) =>
-            val mainIndex = items.indexOf(todoItems()(selectedIndex))
+            val todos = todoItems()
+            val mainIndex = items.indexOf(todos(selectedIndex))
             items(mainIndex) =
               items(mainIndex).copy(status = items(mainIndex).status.progress())
+            // We special case this to make sure that if a user progresses an
+            // item at the bottom of the list, we move the selected up.
+            if selectedIndex + 1 == todos.length then previous() else ()
       case Status.INPROGRESS =>
         inProgressState.selected match
           case None => ()
           case Some(selectedIndex) =>
-            val mainIndex = items.indexOf(inProgressItems()(selectedIndex))
+            val inProgress = inProgressItems()
+            val mainIndex = items.indexOf(inProgress(selectedIndex))
             items(mainIndex) =
               items(mainIndex).copy(status = items(mainIndex).status.progress())
+            if selectedIndex + 1 == inProgress.length then previous() else ()
       case _ => ()
 
   /** Delete the current focused item.

--- a/skan/src/ContextState.scala
+++ b/skan/src/ContextState.scala
@@ -1,7 +1,9 @@
 package skan
 
 /** The top level state of the application containing all of the various
-  * contexts.
+  * contexts. For most operations that have to do with the selected board this
+  * just acts as a facilators and calls the correct operation on the the correct
+  * board.
   *
   * @param boards
   *   The boards contained in the state, aka all the contexts and their name.

--- a/skan/test/uiSuite.scala
+++ b/skan/test/uiSuite.scala
@@ -138,6 +138,53 @@ class uiSuite extends munit.FunSuite:
     )
     assertBuffer(backend, expected)
 
+  test("basic-board-progress-single"):
+    val fresh = ContextState(
+      boards = Map("a" -> BoardState.fromData(defaultItems.slice(0, 1))),
+      activeContext = "a"
+    )
+    val backend = TestBackend(80, 30)
+    val terminal = Terminal.init(backend)
+
+    fresh.progress()
+
+    terminal.draw: frame =>
+      ui.renderBoard(frame, fresh, config)
+
+    val expected = Buffer.with_lines(
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "   ┌Contexts────────────────────────────────────────────────────────────────┐   ",
+      "   │ a                                                                      │   ",
+      "   └────────────────────────────────────────────────────────────────────────┘   ",
+      "   ┌TODOs-0────────────────────────────┐┌In Progress────────────────────────┐   ",
+      "   │                                   ││NORMAL                   2023-04-12│   ",
+      "   │                                   ││Here is a normal one               │   ",
+      "   │                                   ││Some description                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   └───────────────────────────────────┘└───────────────────────────────────┘   ",
+      "   j (down) | k (up) | h (left) | l (right) | ENTER (progress) | n (new) | q    ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                "
+    )
+    assertBuffer(backend, expected)
+
   test("empty-board-basic"):
     val state = ContextState(
       boards = Map("empty" -> BoardState.fromData(Vector.empty)),


### PR DESCRIPTION
Another small fix here that only happened when you were progressing the
final item in the list. Now if you do that we select the previous item.
