### PR TITLE
fix: make sure when you delete the count is correct

### DIFF
--- a/skan/src/BoardState.scala
+++ b/skan/src/BoardState.scala
@@ -126,14 +126,29 @@ final case class BoardState(
         todoState.selected match
           case None => this
           case Some(selectedIndex) =>
-            val mainIndex = items.indexOf(todoItems()(selectedIndex))
-            this.copy(items = items.filterNot(_ == items(mainIndex)))
+            val todos = todoItems()
+            if todos.isEmpty then this
+            else
+              val mainIndex = items.indexOf(todos(selectedIndex))
+              val newState =
+                this.copy(items = items.filterNot(_ == items(mainIndex)))
+              if selectedIndex + 1 >= todos.length - 1 then newState.previous()
+              else ()
+              newState
       case Status.INPROGRESS =>
         inProgressState.selected match
           case None => this
           case Some(selectedIndex) =>
-            val mainIndex = items.indexOf(inProgressItems()(selectedIndex))
-            this.copy(items = items.filterNot(_ == items(mainIndex)))
+            val inProgress = inProgressItems()
+            if inProgress.isEmpty then this
+            else
+              val mainIndex = items.indexOf(inProgress(selectedIndex))
+              val newState =
+                this.copy(items = items.filterNot(_ == items(mainIndex)))
+              if selectedIndex + 1 >= inProgress.length - 1 then
+                newState.previous()
+              else ()
+              newState
       case _ => this
 
   /** Add a new item to the items in this state.

--- a/skan/test/uiSuite.scala
+++ b/skan/test/uiSuite.scala
@@ -289,6 +289,101 @@ class uiSuite extends munit.FunSuite:
     )
     assertBuffer(backend, expected)
 
+  test("basic-board-delete"):
+    val state = ContextState(
+      boards = Map("a" -> BoardState.fromData(defaultItems)),
+      activeContext = "a"
+    )
+    val backend = TestBackend(80, 30)
+    val terminal = Terminal.init(backend)
+
+    val newState = state.delete()
+
+    terminal.draw: frame =>
+      ui.renderBoard(frame, newState, config)
+
+    val expected = Buffer.with_lines(
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "   ┌Contexts────────────────────────────────────────────────────────────────┐   ",
+      "   │ a                                                                      │   ",
+      "   └────────────────────────────────────────────────────────────────────────┘   ",
+      "   ┌TODOs-1/2──────────────────────────┐┌In Progress────────────────────────┐   ",
+      "   │LOW                      2023-04-12││URGENT                   2023-04-12│   ",
+      "   │Here is a low one                  ││An urgent issue with no descript...│   ",
+      "   │Some lowly description             ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │IMPORTANT                2023-04-12││                                   │   ",
+      "   │Here is an Important issue         ││                                   │   ",
+      "   │Short description                  ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   └───────────────────────────────────┘└───────────────────────────────────┘   ",
+      "   j (down) | k (up) | h (left) | l (right) | ENTER (progress) | n (new) | q    ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                "
+    )
+    assertBuffer(backend, expected)
+
+  test("basic-board-delete-single"):
+    val state = ContextState(
+      boards = Map("a" -> BoardState.fromData(defaultItems.slice(0, 1))),
+      activeContext = "a"
+    )
+    val backend = TestBackend(80, 30)
+    val terminal = Terminal.init(backend)
+
+    val first = state.delete()
+    val second = first.delete()
+
+    terminal.draw: frame =>
+      ui.renderBoard(frame, second, config)
+
+    val expected = Buffer.with_lines(
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "   ┌Contexts────────────────────────────────────────────────────────────────┐   ",
+      "   │ a                                                                      │   ",
+      "   └────────────────────────────────────────────────────────────────────────┘   ",
+      "   ┌TODOs-0────────────────────────────┐┌In Progress────────────────────────┐   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   │                                   ││                                   │   ",
+      "   └───────────────────────────────────┘└───────────────────────────────────┘   ",
+      "   j (down) | k (up) | h (left) | l (right) | ENTER (progress) | n (new) | q    ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                "
+    )
+    assertBuffer(backend, expected)
+
   test("basic-input-normal"):
     val backend = TestBackend(80, 25)
     val terminal = Terminal.init(backend)


### PR DESCRIPTION
Same issue we had before with the progress, if you're on the last item
the count can get screwed up due to what is still selected. This change
ensures that it's always correct
