### PR TITLE
feat: start user in input mode on the new item screen

### DIFF
--- a/skan/src/NewItemState.scala
+++ b/skan/src/NewItemState.scala
@@ -51,7 +51,8 @@ object NewItemState:
     * @return
     *   The fresh InputState
     */
-  def fresh(): NewItemState = NewItemState(focusedInput = InputSection.Title)
+  def fresh(): NewItemState =
+    NewItemState(focusedInput = InputSection.Title, inputMode = InputMode.Input)
 
 /** Represents the two states a user can be in during the Input view. Normal,
   * where they are just viewing, and Input where they are editing.

--- a/skan/test/NewItemStateSuite.scala
+++ b/skan/test/NewItemStateSuite.scala
@@ -5,17 +5,17 @@ class NewItemStateSuite extends munit.FunSuite:
     val state = NewItemState.fresh()
     assertEquals(state.title, "")
     assertEquals(state.description, "")
-    assertEquals(state.inputMode, InputMode.Normal)
+    assertEquals(state.inputMode, InputMode.Input)
     assertEquals(state.priority, Priority.NORMAL)
     assertEquals(state.focusedInput, InputSection.Title)
 
   test("can-switch-inputmode"):
     val state = NewItemState.fresh()
-    assertEquals(state.inputMode, InputMode.Normal)
+    assertEquals(state.inputMode, InputMode.Input)
     val swapped = state.switchInputMode()
-    assertEquals(swapped.inputMode, InputMode.Input)
-    val backToNormal = swapped.switchInputMode()
-    assertEquals(backToNormal.inputMode, InputMode.Normal)
+    assertEquals(swapped.inputMode, InputMode.Normal)
+    val backToInput = swapped.switchInputMode()
+    assertEquals(backToInput.inputMode, InputMode.Input)
 
   test("can-focus-next"):
     val state = NewItemState.fresh()

--- a/skan/test/ui/NewItemUiSuite.scala
+++ b/skan/test/ui/NewItemUiSuite.scala
@@ -7,8 +7,40 @@ import skan.InputMode
 import Util.*
 
 class NewItemUiSuite extends munit.FunSuite:
+  test("basic-input-fresh"):
+    val inputState = NewItemState.fresh()
+    val expected = Buffer.with_lines(
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "   ┌Title───────────────────────────────────────────────────────────────────┐   ",
+      "   │                                                                        │   ",
+      "   └────────────────────────────────────────────────────────────────────────┘   ",
+      "   ┌Description─────────────────────────────────────────────────────────────┐   ",
+      "   │                                                                        │   ",
+      "   └────────────────────────────────────────────────────────────────────────┘   ",
+      "   ┌Priority────────────────────────────────────────────────────────────────┐   ",
+      "   │ LOW │ NORMAL │ IMPORTANT │ URGENT                                      │   ",
+      "   └────────────────────────────────────────────────────────────────────────┘   ",
+      "   ENTER (next) | ESC (stop editing)                                            ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                ",
+      "                                                                                "
+    )
+    checkInputUi(inputState, expected)
+
   test("basic-input-normal"):
     val inputState = NewItemState.fresh()
+    val newState = inputState.switchInputMode()
     val expected = Buffer.with_lines(
       "                                                                                ",
       "                                                                                ",
@@ -36,7 +68,7 @@ class NewItemUiSuite extends munit.FunSuite:
       "                                                                                ",
       "                                                                                "
     )
-    checkInputUi(inputState, expected)
+    checkInputUi(newState, expected)
 
   test("basic-input-filled"):
     val inputState = NewItemState


### PR DESCRIPTION
Now when a user goes to the new item screen they'll start in input mode
so they can just start typing right away instead.

closes #37
