### PR TITLE
chore(ci): take out prepare-for-graal calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,7 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: VirtusLab/scala-cli-setup@main
 
-      - run: |
-          make prepare-for-graal package-mac
-          chmod +x out/skan
+      - run: make package-mac
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -62,9 +60,7 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: VirtusLab/scala-cli-setup@main
 
-      - run: |
-          make prepare-for-graal package-linux
-          chmod +x out/skan
+      - run: make package-linux
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Now that we call these automatically in the package tasks
we don't need them here anymore.
