### PR TITLE
fix: show 0 at start in TODOs if empty

### DIFF
--- a/skan/src/ui/Board.scala
+++ b/skan/src/ui/Board.scala
@@ -119,6 +119,11 @@ object Board:
     val todoBorderTitle =
       if state.focusedList == Status.TODO then
         state.todoState.selected match
+          case Some(_) if todoItems.size == 0 =>
+            Spans.styled(
+              s"TODOs-${todoItems.size}",
+              Style.DEFAULT.fg(Color.Yellow)
+            )
           case Some(index) =>
             Spans.styled(
               s"TODOs-${index + 1}/${todoItems.size}",


### PR DESCRIPTION
This makes sure that when you start with a board that has an empty
TODO column, but does have items that it correctly shows 0 in TODOs.

Closes #48
