### PR TITLE
feat: add in an archive directory for deleted contexts

### DIFF
--- a/skan/src/Config.scala
+++ b/skan/src/Config.scala
@@ -26,6 +26,7 @@ object Config:
   private val configDir = projectDirs.configDir
   private lazy val defaultDataDir = os.Path(dataDir) / "contexts"
   val configFile = os.Path(configDir) / "config.json"
+  val archiveDir = os.Path(dataDir) / "archive"
 
   private def fromJson(json: String) =
     upickle.default.read[Config](json)


### PR DESCRIPTION
By default we used to just blow away a context when it was deleted.
Instead now we archive it by default. In the future we can probably
expand on this and choose to maybe bring back a context or add a setting
to really delete it instead of archiving it.
